### PR TITLE
Allow syntax highlighting in sanitized markdown.

### DIFF
--- a/app/views/questions/show.html.haml
+++ b/app/views/questions/show.html.haml
@@ -11,7 +11,7 @@
     = queue_status(@question)
   .row
     .small-8.columns
-      %p.body~ render_markdown(@question.body)
+      %p.body~ render_safe_markdown(@question.body)
     .small-4.columns
       .user
         = link_to @question.user.username, user_path(@question.user)
@@ -29,7 +29,7 @@
     - if answer.persisted?
       .row.answer
         .small-8.columns
-          %p.body~ render_markdown(answer.body)
+          %p.body~ render_safe_markdown(answer.body)
           - if answer.user == current_user
             = link_to "Edit Answer", edit_question_answer_path(@question, answer), class: "button tiny success"
             = link_to "Delete Answer", question_answer_path(@question, answer), method: :delete, class: "button tiny alert"

--- a/lib/markdown_renderer.rb
+++ b/lib/markdown_renderer.rb
@@ -6,10 +6,16 @@ class Markdown
   end
 
   def self.render_safe(content)
-    Sanitize.fragment(renderer.render(content), Sanitize::Config::BASIC)
+    Sanitize.fragment(renderer.render(content), sanitizer_config)
   end
 
   private
+
+  def self.sanitizer_config
+    Sanitize::Config.merge(Sanitize::Config::BASIC,
+      elements: Sanitize::Config::BASIC[:elements] + ["span"],
+      attributes: { "span" => ["class"], "code" => ["class"] })
+  end
 
   def self.renderer
     Redcarpet::Markdown.new(HighlightingRenderer,


### PR DESCRIPTION
The sanitizer gem was stripping out the `<span>` tags from the
rendered code blocks which prevented the CSS syntax highlighting
from taking effect. Allowing the `class` attribute for `<span>`
and `<code>` tags seems pretty safe.

More info: https://github.com/rgrove/sanitize#custom-configuration