### PR TITLE
Update markdown styling for readability

### DIFF
--- a/app/assets/stylesheets/modules/lesson.css.scss
+++ b/app/assets/stylesheets/modules/lesson.css.scss
@@ -14,6 +14,7 @@
 
 .lesson-type {
   padding: 10px;
+  margin-top: 1em;
   border: 1px solid $border-color;
   border-radius: 3px;
 

--- a/app/assets/stylesheets/modules/markdown.css.scss
+++ b/app/assets/stylesheets/modules/markdown.css.scss
@@ -1,10 +1,10 @@
 .lesson-container {
-  max-width: 60em;
   margin: 1em auto;
+  max-width: 60em;
   padding: 0 2em;
 
-  border-left: 1px solid #ddd;
-  border-right: 1px solid #ddd;
+  border-left: 1px solid $border-color;
+  border-right: 1px solid $border-color;
 
 }
 
@@ -29,14 +29,14 @@
     padding-bottom: 0.3em;
     font-size: 2.25em;
     line-height: 1.2;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid $border-color;
   }
 
   h2 {
     padding-bottom: 0.3em;
     font-size: 1.75em;
     line-height: 1.225;
-    border-bottom: 1px solid #eee;
+    border-bottom: 1px solid $border-color;
   }
 
   h3 {
@@ -60,14 +60,14 @@
   blockquote {
     padding: 0 15px;
     color: #777;
-    border-left: 4px solid #ddd;
+    border-left: 4px solid $border-color;
   }
 
   hr {
     height: 4px;
     padding: 0;
     margin: 16px 0;
-    background-color: #e7e7e7;
+    background-color: $border-color;
     border: 0 none;
   }
 }

--- a/app/assets/stylesheets/modules/markdown.css.scss
+++ b/app/assets/stylesheets/modules/markdown.css.scss
@@ -1,0 +1,73 @@
+.lesson-container {
+  max-width: 60em;
+  margin: 1em auto;
+  padding: 0 2em;
+
+  border-left: 1px solid #ddd;
+  border-right: 1px solid #ddd;
+
+}
+
+.lesson-container #body {
+  p, blockquote, ul, ol, dl, table {
+    margin-top: 0;
+    margin-bottom: 16px;
+  }
+
+  ul, ol {
+    padding-left: 2em;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    font-weight: bold;
+    margin-top: 1em;
+    margin-bottom: 16px;
+    line-height: 1.4;
+  }
+
+  h1 {
+    padding-bottom: 0.3em;
+    font-size: 2.25em;
+    line-height: 1.2;
+    border-bottom: 1px solid #eee;
+  }
+
+  h2 {
+    padding-bottom: 0.3em;
+    font-size: 1.75em;
+    line-height: 1.225;
+    border-bottom: 1px solid #eee;
+  }
+
+  h3 {
+    font-size: 1.5em;
+    line-height: 1.43;
+  }
+
+  h4 {
+    font-size: 1.25em;
+  }
+
+  h5 {
+    font-size: 1em;
+  }
+
+  h6 {
+    font-size: 1em;
+    color: #777;
+  }
+
+  blockquote {
+    padding: 0 15px;
+    color: #777;
+    border-left: 4px solid #ddd;
+  }
+
+  hr {
+    height: 4px;
+    padding: 0;
+    margin: 16px 0;
+    background-color: #e7e7e7;
+    border: 0 none;
+  }
+}

--- a/app/assets/stylesheets/modules/markdown.css.scss
+++ b/app/assets/stylesheets/modules/markdown.css.scss
@@ -11,7 +11,7 @@
 }
 
 .lesson-container #body {
-  p, blockquote, ul, ol, dl, table {
+  p, blockquote, ul, ol, dl, table, pre {
     margin-top: 0;
     margin-bottom: 16px;
   }
@@ -71,5 +71,12 @@
     margin: 16px 0;
     background-color: $border-color;
     border: 0 none;
+  }
+
+  pre {
+    padding: 16px;
+    overflow: auto;
+    font-size: 85%;
+    line-height: 1.45;
   }
 }

--- a/app/assets/stylesheets/modules/markdown.css.scss
+++ b/app/assets/stylesheets/modules/markdown.css.scss
@@ -1,3 +1,5 @@
+@import "globals/colors";
+
 .lesson-container {
   margin: 1em auto;
   max-width: 60em;

--- a/app/assets/stylesheets/modules/spacing.css.scss
+++ b/app/assets/stylesheets/modules/spacing.css.scss
@@ -7,7 +7,7 @@
  /* ====== Default spacing ====== */
 /* h1, h2, h3, h4, h5, h6, ul, ol,dl, p,blockquote, .media {margin:10px;} */
 h1, h2, h3, h4, h5, h6,img{padding-bottom:0px;}
-pre{margin: 10px;}
+/* pre{margin: 10px;} */
 table h1,table h2,table h3, table h4, table h5, table h6, table p, table ul, table ol, table dl{padding:0;}
 
 /* spacing helpers

--- a/app/assets/stylesheets/modules/spacing.css.scss
+++ b/app/assets/stylesheets/modules/spacing.css.scss
@@ -5,7 +5,7 @@
  * <type><location><size>
  */
  /* ====== Default spacing ====== */
-h1, h2, h3, h4, h5, h6, ul, ol,dl, p,blockquote, .media {margin:10px;}
+/* h1, h2, h3, h4, h5, h6, ul, ol,dl, p,blockquote, .media {margin:10px;} */
 h1, h2, h3, h4, h5, h6,img{padding-bottom:0px;}
 pre{margin: 10px;}
 table h1,table h2,table h3, table h4, table h5, table h6, table p, table ul, table ol, table dl{padding:0;}

--- a/app/views/lessons/show.html.haml
+++ b/app/views/lessons/show.html.haml
@@ -7,20 +7,19 @@
   - if @lesson.accepts_submissions?
     %li= link_to "Submissions", lesson_submissions_path(@lesson)
 
+.lesson-container.clearfix
+  .lesson-type{ class: @lesson.type }= @lesson.type
+  %h2.lesson-title= @lesson.title
 
-.lesson-type{ class: @lesson.type }= @lesson.type
+  - if @lesson.tags.any?
+    %dl.sub-nav
+      %dt Tags:
+      - @lesson.tags.each do |tag|
+        %dd
+          %span.label.radius= tag.name
 
-%h2.lesson-title= @lesson.title
-
-- if @lesson.tags.any?
-  %dl.sub-nav
-    %dt Tags:
-    - @lesson.tags.each do |tag|
-      %dd
-        %span.label.radius= tag.name
-
-#body
-  ~ render_markdown(@lesson.body)
+  #body
+    ~ render_markdown(@lesson.body)
 
 - if user_signed_in?
   #rating


### PR DESCRIPTION
Also, comment out piece of CSS that was decreasing readability on the site in general.

Copied styles from Github's markdown rendering - decreasing width, adding better spacing, making headings bold, etc. See attached pics for before and after comparison.
![before](https://cloud.githubusercontent.com/assets/8670086/6529320/dc1d4de6-c3f5-11e4-9a7d-d78047bf0b87.png)
![after](https://cloud.githubusercontent.com/assets/8670086/6529324/dec4984c-c3f5-11e4-899e-129b128396c7.png)