### PR TITLE
Remove duplicate gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,8 +47,6 @@ end
 group :test do
   gem "coveralls", require: false
   gem "launchy", require: false
-  gem "shoulda-matchers"
-  gem 'valid_attribute'
   gem "mocha", require: false
   gem "webmock"
   gem "database_cleaner"


### PR DESCRIPTION
These gems were listed in two separate blocks in the Gemfile. This
resulted in warnings when deploying to heroku.