### PR TITLE
Tweak lesson styles

### DIFF
--- a/app/assets/stylesheets/modules/markdown.css.scss
+++ b/app/assets/stylesheets/modules/markdown.css.scss
@@ -2,12 +2,7 @@
 
 .lesson-container {
   margin: 1em auto;
-  max-width: 60em;
-  padding: 0 2em;
-
-  border-left: 1px solid $border-color;
-  border-right: 1px solid $border-color;
-
+  padding: 0;
 }
 
 .lesson-container #body {


### PR DESCRIPTION
Allow the lesson to fill the width of the parent container. Remove
double borders.